### PR TITLE
Fallback to using interface address when looking for local address

### DIFF
--- a/onionperf/util.py
+++ b/onionperf/util.py
@@ -9,6 +9,8 @@ from subprocess import Popen, PIPE, STDOUT
 from threading import Lock
 from cStringIO import StringIO
 from abc import ABCMeta, abstractmethod
+import netifaces
+import ipaddress
 
 LINEFORMATS = "k-,r-,b-,g-,c-,m-,y-,k--,r--,b--,g--,c--,m--,y--,k:,r:,b:,g:,c:,m:,y:,k-.,r-.,b-.,g-.,c-.,m-.,y-."
 
@@ -112,6 +114,14 @@ def do_dates_match(date1, date2):
 
 def get_ip_address():
     ip_address = None
+
+    for inf in netifaces.interfaces():
+	if netifaces.AF_INET in netifaces.ifaddresses(inf):
+	    for addr in netifaces.ifaddresses(inf)[netifaces.AF_INET]:
+		if 'addr' in addr:
+		    address = ipaddress.ip_address(addr['addr'])
+		    if not address.is_loopback and not address.is_link_local:
+			return address
 
     data = urllib.urlopen('https://check.torproject.org/').read()
     if data is not None and len(data) > 0:


### PR DESCRIPTION
If we are running in an isolated network, getting our local address by
connecting out and reading the sock addr (via check.torprojectc.org or
connecting to 8.8.8.8) will fail. In that case use the first non link
local non loopback address from our interfaces.